### PR TITLE
chore: unload markdown-it-anchor plugin

### DIFF
--- a/build/md-loader/config.js
+++ b/build/md-loader/config.js
@@ -1,6 +1,6 @@
 const Config = require('markdown-it-chain')
-const anchorPlugin = require('markdown-it-anchor')
-const slugify = require('transliteration').slugify
+// const anchorPlugin = require('markdown-it-anchor')
+// const slugify = require('transliteration').slugify
 const hljs = require('highlight.js')
 
 const containers = require('./containers')
@@ -22,20 +22,23 @@ config.options
   .highlight(highlight)
   .end()
 
-  .plugin('anchor')
-  .use(anchorPlugin, [
-    {
-      level: 2,
-      slugify: slugify,
-      permalink: true,
-      permalinkBefore: true
-    }
-  ])
-  .end()
-
   .plugin('containers')
   .use(containers)
   .end()
+
+// 这个插件生成的 href 没有带前缀，导致报错，
+// 例如：http://0.0.0.0:8086/#/npm-an-zhuang
+// http://0.0.0.0:8086/#/zh-CN/component/installation#npm-an-zhuang
+// .plugin('anchor')
+// .use(anchorPlugin, [
+//   {
+//     level: 2,
+//     slugify: slugify,
+//     permalink: true,
+//     permalinkBefore: true
+//   }
+// ])
+// .end()
 
 const md = config.toMd()
 overWriteFenceRule(md)


### PR DESCRIPTION
markown-it-chain 取消加载anchor插件

请提交PR之前确认一下已通过

1. 看过这个贡献者说明  [中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md)
2. 测试通过
3. 如果有相关的issue，记得关联上
