### PR TITLE
docs: fix use message api 

### DIFF
--- a/examples/docs/zh-CN/message.md
+++ b/examples/docs/zh-CN/message.md
@@ -197,13 +197,13 @@
 </template>
 
 <script>
-  import { Message } from 'element3'
+  import { useMessage } from 'element3'
   export default {
     setup() {
-
+      const message = useMessage()
       return {
         openHTML() {
-          Message({
+          message({
             dangerouslyUseHTMLString: true,
             verticalOffset: 100,
             message: '<strong>这是 <i>HTML</i> 片段</strong>'


### PR DESCRIPTION
请提交PR之前确认一下已通过
文档引入 Message 不对 

 更改前
```
<template>
  <el-button :plain="true" @click="openHTML">使用 HTML 片段</el-button>
</template>

<script>
  import { Message } from 'element3'
  export default {
    setup() {

      return {
        openHTML() {
          Message({
            dangerouslyUseHTMLString: true,
            verticalOffset: 100,
            message: '<strong>这是 <i>HTML</i> 片段</strong>'
          })
        }
      }
    }
  }
</script>
```
更改后 
```
<template>
  <el-button :plain="true" @click="openHTML">使用 HTML 片段</el-button>
</template>

<script>
  import { useMessage } from 'element3'
  export default {
    setup() {
      const message = useMessage()
      return {
        openHTML() {
          message({
            dangerouslyUseHTMLString: true,
            verticalOffset: 100,
            message: '<strong>这是 <i>HTML</i> 片段</strong>'
          })
        }
      }
    }
  }
</script>
```

1. 看过这个贡献者说明  [中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md)
2. 测试通过
3. 如果有相关的issue，记得关联上
