### PR TITLE
fix: option select bug

### DIFF
--- a/packages/element3/packages/option/Option.vue
+++ b/packages/element3/packages/option/Option.vue
@@ -192,7 +192,7 @@ export default {
       itemSelected,
       limitReached,
       currentLabel,
-      currentValue,
+      value:currentValue,
       hoverItem
     }
   }


### PR DESCRIPTION
修复ELOption组件暴露出的变量名称不对问题，
在ELSelect中使用option.value无法获取到其值
