### PR TITLE
test(timeline.spec.js): timeline的测试覆盖率从92.31 75 100 92.31提升到100 87.5 …

### DIFF
--- a/packages/element3/packages/timeline/__tests__/Timeline.spec.js
+++ b/packages/element3/packages/timeline/__tests__/Timeline.spec.js
@@ -1,7 +1,7 @@
 import Timeline from '../Timeline.vue'
 import TimelineItem from '../../timeline-item/TimelineItem'
 import { mount } from '@vue/test-utils'
-import { ref, h } from 'vue'
+import { ref, h, Fragment } from 'vue'
 describe('TimeLine Test', () => {
   it('create', () => {
     const activities = ref([
@@ -18,6 +18,7 @@ describe('TimeLine Test', () => {
         timestamp: '2020-11-15'
       }
     ])
+    // mount 挂载和渲染一个vue组件
     const wrapper = mount(Timeline, {
       data() {
         return {
@@ -25,6 +26,7 @@ describe('TimeLine Test', () => {
         }
       },
       slots: {
+        // 子组件是一个TimelineItem
         default: activities.value.map((activity, index) => {
           return h(
             TimelineItem,
@@ -33,6 +35,7 @@ describe('TimeLine Test', () => {
               timestamp: activities.value[index].timestamp
             },
             () => {
+              // 文本内容
               return activities.value[index].content
             }
           )
@@ -91,10 +94,12 @@ describe('TimeLine Test', () => {
     const vm = wrapper.vm
     let contentElms = wrapper.findAll('.el-timeline-item__content')
     contentElms.forEach(({ element: elm }, index) => {
+      // vm.data.value[index] -> {content: '', timestamp: ''}
       expect(elm.textContent).toEqual(
         vm.activities.value[vm.activities.value.length - index - 1].content
       )
     })
+    // 异步更改属性
     await wrapper.setProps({
       reverse: false
     })
@@ -103,7 +108,7 @@ describe('TimeLine Test', () => {
       expect(elm.textContent).toEqual(vm.activities.value[index].content)
     })
   })
-  it('placement', async () => {
+  it('placement: top', async () => {
     const activities = ref([
       {
         content: '创建成功',
@@ -144,6 +149,47 @@ describe('TimeLine Test', () => {
     let timestampElm = wrapper.find('.el-timeline-item__timestamp')
     expect(timestampElm.classes('is-top')).toBe(true)
   })
+  it('placement: bottom', async () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        placement: 'bottom'
+      },
+      {
+        content: '通过审核',
+        timestamp: '2020-11-12'
+      },
+      {
+        content: '活动按期开始',
+        timestamp: '2020-11-15'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            TimelineItem,
+            {
+              key: index,
+              timestamp: activities.value[index].timestamp,
+              placement: activities.value[index].placement
+            },
+            () => {
+              return activities.value[index].content
+            }
+          )
+        })
+      }
+    })
+    let timestampElm = wrapper.find('.el-timeline-item__timestamp')
+    expect(timestampElm.classes('is-bottom')).toBe(true)
+  })
   it('hide-timestamp', async () => {
     const activities = ref([
       {
@@ -182,6 +228,7 @@ describe('TimeLine Test', () => {
         })
       }
     })
+    // 隐藏时间戳，时间戳的长度少一个
     let timestampElms = wrapper.findAll('.el-timeline-item__timestamp')
     expect(timestampElms.length).toEqual(2)
   })
@@ -223,10 +270,11 @@ describe('TimeLine Test', () => {
         })
       }
     })
+    // wrapper.find('.class').element 获取元素
     let nodeElm = wrapper.find('.el-timeline-item__node').element
     expect(nodeElm.style.backgroundColor).toEqual('rgb(255, 0, 0)')
   })
-  it('type', () => {
+  it('type:primary', () => {
     const activities = ref([
       {
         content: '创建成功',
@@ -259,8 +307,140 @@ describe('TimeLine Test', () => {
     let nodeElm = wrapper.find('.el-timeline-item__node')
     expect(nodeElm.classes()).toContain('el-timeline-item__node--primary')
   })
+  it('type:success', () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        type: 'success'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            TimelineItem,
+            {
+              key: index,
+              timestamp: activities.value[index].timestamp,
+              type: activities.value[index].type
+            },
+            () => {
+              return activities.value[index].content
+            }
+          )
+        })
+      }
+    })
+    let nodeElm = wrapper.find('.el-timeline-item__node')
+    expect(nodeElm.classes()).toContain('el-timeline-item__node--success')
+  })
+  it('type:warning', () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        type: 'warning'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            TimelineItem,
+            {
+              key: index,
+              timestamp: activities.value[index].timestamp,
+              type: activities.value[index].type
+            },
+            () => {
+              return activities.value[index].content
+            }
+          )
+        })
+      }
+    })
+    let nodeElm = wrapper.find('.el-timeline-item__node')
+    expect(nodeElm.classes()).toContain('el-timeline-item__node--warning')
+  })
+  it('type:danger', () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        type: 'danger'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            TimelineItem,
+            {
+              key: index,
+              timestamp: activities.value[index].timestamp,
+              type: activities.value[index].type
+            },
+            () => {
+              return activities.value[index].content
+            }
+          )
+        })
+      }
+    })
+    let nodeElm = wrapper.find('.el-timeline-item__node')
+    expect(nodeElm.classes()).toContain('el-timeline-item__node--danger')
+  })
+  it('type:info', () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        type: 'info'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            TimelineItem,
+            {
+              key: index,
+              timestamp: activities.value[index].timestamp,
+              type: activities.value[index].type
+            },
+            () => {
+              return activities.value[index].content
+            }
+          )
+        })
+      }
+    })
+    let nodeElm = wrapper.find('.el-timeline-item__node')
+    expect(nodeElm.classes()).toContain('el-timeline-item__node--info')
+  })
 
-  it('size', () => {
+  it('size: large', () => {
     const activities = ref([
       {
         content: '创建成功',
@@ -292,6 +472,39 @@ describe('TimeLine Test', () => {
     })
     let nodeElm = wrapper.find('.el-timeline-item__node')
     expect(nodeElm.classes()).toContain('el-timeline-item__node--large')
+  })
+  it('size: normal', () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        type: 'normal'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            TimelineItem,
+            {
+              key: index,
+              timestamp: activities.value[index].timestamp,
+              type: activities.value[index].type
+            },
+            () => {
+              return activities.value[index].content
+            }
+          )
+        })
+      }
+    })
+    let nodeElm = wrapper.find('.el-timeline-item__node')
+    expect(nodeElm.classes()).toContain('el-timeline-item__node--normal')
   })
 
   it('icon', () => {
@@ -326,5 +539,47 @@ describe('TimeLine Test', () => {
     })
     let nodeElm = wrapper.find('.el-timeline-item__icon')
     expect(nodeElm.classes()).toContain('el-icon-more')
+  })
+  it("slot's type is Fragment, its children's length is activities.length", () => {
+    const activities = ref([
+      {
+        content: '创建成功',
+        timestamp: '2020-11-11',
+        type: 'danger'
+      },
+      {
+        content: '第二个内容',
+        timestamp: '2020-11-10',
+        type: 'danger'
+      }
+    ])
+    const wrapper = mount(Timeline, {
+      data() {
+        return {
+          activities: activities
+        }
+      },
+      slots: {
+        default: activities.value.map((activity, index) => {
+          return h(
+            Fragment,
+            {},
+            h(
+              TimelineItem,
+              {
+                key: index,
+                timestamp: activities.value[index].timestamp,
+                type: activities.value[index].type
+              },
+              () => {
+                return activities.value[index].content
+              }
+            )
+          )
+        })
+      }
+    })
+    let nodeElm = wrapper.findAll('.el-timeline-item__node')
+    expect(nodeElm.length).toEqual(2)
   })
 })


### PR DESCRIPTION
…100 100

timeline测试增加了当插槽类型为fragment的情况，和type、size、placement的各属性的测试补全，

请提交 PR 之前确认一下已通过

1. 看过这个贡献者说明 [中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md)
2. 测试通过
3. 如果有相关的 issue，记得关联上
